### PR TITLE
Fix screenshot headers & heights

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -295,7 +295,7 @@ figure {
 }
 
 figcaption {
-	background-color: rgba(255, 255, 255, 0.9);
+	background-color: var(--background);
 	position: absolute;
 	padding: 0.75em;
 	left: 1em;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -294,6 +294,12 @@ figure {
 	margin: 1em 0;
 }
 
+@supports not (aspect-ratio: 1/1) {
+	figure {
+		height: 60vh;
+	}
+}
+
 figcaption {
 	background-color: var(--background);
 	position: absolute;


### PR DESCRIPTION
This PR:
- fixes screenshot headers in dark mode - I forgot to use a CSS variable here [closes #11]
- adds a fallback for browsers that don't support the CSS property `aspect-ratio` [closes #12]