### PR TITLE
Replace U+2E31 with U+00B7 (middle dot) in footer

### DIFF
--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -3,7 +3,7 @@
     <div class="footer__inner">
       <div class="footer__copy">
         <span>
-          <strong>&copy; 2021&ndash;{% year %} ⸱ The Airyx Project</strong> ⸱ All Rights Reserved.
+          <strong>&copy; 2021&ndash;{% year %} · The Airyx Project</strong> · All Rights Reserved.
         </span>
         <small>
           "Airyx" and the airyx logo are trademarks. The other trademarks or


### PR DESCRIPTION
The footer is using 'WORD SEPARATOR MIDDLE DOT' (U+2E31), which seems to be a fairly uncommon code point as I don't have a font containing a glyph for it on my Linux system. This PR replaces it with 'MIDDLE DOT' (U+00B7), which should be more commonly available.

Here's what I see on the my system as far as the diff goes:

<img width="633" alt="Screenshot from 2022-02-02 08-21-07" src="https://user-images.githubusercontent.com/21787/152061570-487b12ce-befb-4732-9684-778991cc7993.png">

And here's what it looks like before and after on a macOS system that did have a glyph for U+2E31 (so you can compare the small visual difference):

**Before**

<img width="777" alt="Screenshot 2022-02-02 at 08-18-29 airyxOS – Finesse of macOS Freedom of FreeBSD " src="https://user-images.githubusercontent.com/21787/152061749-94bdc571-47b5-4a3d-8eeb-0c98721f8f8c.png">

**After**

<img width="777" alt="Screenshot 2022-02-02 at 08-19-18 airyxOS – Finesse of macOS Freedom of FreeBSD " src="https://user-images.githubusercontent.com/21787/152061743-6534190d-815d-4089-8e62-12ad025581a7.png">

